### PR TITLE
Fix hover rendering slowness

### DIFF
--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -62,19 +62,19 @@ export default Vue.extend({
       };
     },
 
-    matrixWidth() {
+    matrixWidth(): number {
       return this.visDimensions.width * 0.75;
     },
 
-    matrixHeight() {
+    matrixHeight(): number {
       return this.visDimensions.height;
     },
 
-    attributesWidth() {
+    attributesWidth(): number {
       return this.visDimensions.width * 0.25 - 15; // 15 for the scrollbar
     },
 
-    attributesHeight() {
+    attributesHeight(): number {
       return this.matrixHeight;
     },
   },

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -112,7 +112,12 @@ export default Vue.extend({
       .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
 
     // Define the View
-    this.view = new View(this.network, this.visDimensions, this.visualizedAttributes);
+    this.view = new View(
+      this.network,
+      this.visualizedAttributes, 
+      this.matrixWidth, 
+      this.matrixHeight
+    );
   },
 
   methods: {

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -61,6 +61,22 @@ export default Vue.extend({
         visualizedAttributes,
       };
     },
+
+    matrixWidth() {
+      return this.visDimensions.width * 0.75;
+    },
+
+    matrixHeight() {
+      return this.visDimensions.height;
+    },
+
+    attributesWidth() {
+      return this.visDimensions.width * 0.25 - 15; // 15 for the scrollbar
+    },
+
+    attributesHeight() {
+      return this.matrixHeight;
+    },
   },
 
   watch: {
@@ -85,15 +101,15 @@ export default Vue.extend({
     // Size the svgs
     this.matrix = d3
       .select(this.$refs.matrix)
-      .attr('width', this.visDimensions.width * 0.75)
-      .attr('height', this.visDimensions.height)
-      .attr('viewBox', `0 0 ${this.visDimensions.width * 0.75} ${this.visDimensions.height}`);
+      .attr('width', this.matrixWidth)
+      .attr('height', this.matrixHeight)
+      .attr('viewBox', `0 0 ${this.matrixWidth} ${this.matrixHeight}`);
 
     this.attributes = d3
       .select(this.$refs.attributes)
-      .attr('width', this.visDimensions.width * 0.25 - 15) // -15 for the scroll bar
-      .attr('height', this.visDimensions.height)
-      .attr('viewBox', `0 0 ${this.visDimensions.width * 0.25 - 15} ${this.visDimensions.height}`);
+      .attr('width', this.attributesWidth) // -15 for the scroll bar
+      .attr('height', this.attributesHeight)
+      .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
 
     // Define the View
     this.view = new View(this.network, this.visDimensions, this.visualizedAttributes);

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
 
     this.attributes = d3
       .select(this.$refs.attributes)
-      .attr('width', this.attributesWidth) // -15 for the scroll bar
+      .attr('width', this.attributesWidth)
       .attr('height', this.attributesHeight)
       .attr('viewBox', `0 0 ${this.attributesWidth} ${this.attributesHeight}`);
 

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -167,18 +167,13 @@ svg >>> .hovered {
   fill-opacity: 1 !important;
 }
 
-svg >>> .clickedCell {
-  stroke-width: 2.5;
-  stroke: #ee0000;
-}
-
 svg >>> .clicked {
   font-weight: 800;
   fill: #f8cf91 !important;
   fill-opacity: 1 !important;
 }
 
-svg >>> .clickedCell {
+svg >>> .cell.clicked {
   stroke: red;
   stroke-width: 3;
 }

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -290,17 +290,17 @@ export class View {
       .domain([0, this.maxNumConnections])
       .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
 
-    const cells = this.edgeRows.selectAll('.cell')
+    this.edgeRows.selectAll('.cell')
       .data((d: Node, i: number) => this.matrix[i])
       .enter()
       .append('rect')
+      .attr('class', 'cell')
+      .attr('id', (d: Cell) => d.cellName)
       .attr('x', (d: Cell) => this.orderingScale(d.x))
       .attr('width', this.orderingScale.bandwidth())
       .attr('height', this.orderingScale.bandwidth())
       .style('fill', (d: Cell) => cellColorScale(d.z))
-      .style('fill-opacity', (d: Cell) => d.z);
-
-    cells
+      .style('fill-opacity', (d: Cell) => d.z)
       .on('mouseover', (d: Cell, i: number, nodes: any) => {
         this.showToolTip(d, i, nodes);
         this.hoverEdge(d);
@@ -309,11 +309,7 @@ export class View {
         this.hideToolTip();
         this.unHoverEdge(d);
       })
-      .on('click', (d: Cell, i: number, nodes: any) => {
-        const interaction = select(nodes[i]).attr('class');
-        const action = this.changeInteractionWrapper(interaction, d);
-        this.provenance.applyAction(action);
-      })
+      .on('click', (d: Cell) => this.cellClick(d))
       .attr('cursor', 'pointer');
 
     this.appendEdgeLabels();

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -34,7 +34,6 @@ export class View {
   private columnHeaders: any;
   private attributeScales: { [key: string]: any } = {};
   private colMargin: number = 5;
-  private visDimensions: Dimensions;
   private provenance: any;
   private idMap: { [key: string]: number };
   private isMultiEdge: boolean;
@@ -43,11 +42,17 @@ export class View {
   private selectedElements: { [key: string]: string[] };
   private mouseOverEvents: any;
   private maxNumConnections: number = -Infinity;
+  private matrixWidth: number;
+  private matrixHeight: number;
 
-  constructor(network: Network, visDimensions: any, visualizedAttributes: string[]) {
+  constructor(
+    network: Network,
+    visualizedAttributes: string[],
+    matrixWidth: number,
+    matrixHeight: number,
+  ) {
     this.network = network;
     this.margins = { left: 75, top: 75, right: 0, bottom: 10 };
-    this.visDimensions = visDimensions;
     this.provenance = this.setUpProvenance();
     this.sortKey = 'name';
     this.matrix = [];
@@ -56,6 +61,8 @@ export class View {
     this.selectedNodesAndNeighbors = {};
     this.selectedElements = {};
     this.visualizedAttributes = visualizedAttributes;
+    this.matrixWidth = matrixWidth;
+    this.matrixHeight = matrixHeight;
 
     this.icons = {
       quant: {
@@ -232,7 +239,7 @@ export class View {
    */
   private initializeEdges(): void {
     // Set width and height based upon the calculated layout size. Grab the smaller of the 2
-    const sideLength = Math.min(this.visDimensions.width * 0.75, this.visDimensions.height);
+    const sideLength = Math.min(this.matrixWidth, this.matrixHeight);
 
     // Use the smallest side as the length of the matrix
     this.edgeWidth = sideLength - (this.margins.left + this.margins.right);

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -314,7 +314,7 @@ export class View {
         this.hideToolTip();
         this.unHoverEdge(d);
       })
-      .on('click', (d: Cell) => this.selectElement(d))
+      .on('click', this.selectElement)
       .attr('cursor', 'pointer');
 
     this.appendEdgeLabels();

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -37,7 +37,7 @@ export class View {
   private visDimensions: Dimensions;
   private provenance: any;
   private idMap: { [key: string]: number };
-  private isMultiEdge: any;
+  private isMultiEdge: boolean;
   private orderType: any;
   private selectedNodesAndNeighbors: { [key: string]: string[] };
   private selectedElements: { [key: string]: string[] };
@@ -52,6 +52,7 @@ export class View {
     this.sortKey = 'name';
     this.matrix = [];
     this.idMap = {};
+    this.isMultiEdge = false;
     this.selectedNodesAndNeighbors = {};
     this.selectedElements = {};
     this.visualizedAttributes = visualizedAttributes;
@@ -217,10 +218,12 @@ export class View {
 
   }
 
+
   private isQuantitative(varName: string): boolean {
     const uniqueValues = [...new Set(this.network.nodes.map((node: Node) => parseFloat(node[varName])))];
     return uniqueValues.length > 5;
   }
+
 
   /**
    * initializes the edges view, renders all SVG elements and attaches listeners
@@ -323,6 +326,7 @@ export class View {
       .style('position', 'absolute')
       .style('opacity', 0);
   }
+
 
   /**
    * Draws the nested edge bars
@@ -556,6 +560,7 @@ export class View {
 
   }
 
+
   /**
    * [changeInteractionWrapper description]
    * @param  nodeID ID of the node being changed with
@@ -600,6 +605,7 @@ export class View {
       },
     };
   }
+
 
   /**
    * Adds the interacted node to the state object.
@@ -661,6 +667,7 @@ export class View {
     }
   }
 
+
   /**
    * [sort description]
    * @return [description]
@@ -702,6 +709,7 @@ export class View {
       .filter((d: any) => d.id === order)
       .style('fill', '#EBB769');
   }
+
 
   /**
    * [initializeAttributes description]
@@ -796,9 +804,10 @@ export class View {
 
   private isSelected(node: Node): boolean {
     const currentState = this.getApplicationState();
-    const clicked = currentState.clicked;
-    return clicked.includes(node.id as never);
+    const clicked: string[] = currentState.clicked;
+    return clicked.includes(node.id);
   }
+
 
   private showToolTip(d: any, i: number, nodes: any): void {
     const matrix = nodes[i].getScreenCTM()
@@ -816,10 +825,12 @@ export class View {
       .style('opacity', .9);
   }
 
+
   private hideToolTip(): void {
     this.tooltip.transition(25)
     .style('opacity', 0);
   }
+
 
   private sortObserver(type: string, isNode: boolean = false): number[] {
     let order;
@@ -869,6 +880,7 @@ export class View {
     return order;
   }
 
+
   /**
    * Initializes the provenance library and sets observers.
    * @return [none]
@@ -900,6 +912,7 @@ export class View {
 
     return provenance;
   }
+
 
   /**
    * Initializes the matrix and fills it with link occurrences.
@@ -937,6 +950,7 @@ export class View {
     });
   }
 
+
   /**
    * returns an object containing the current provenance state.
    * @return [the provenance state]
@@ -944,6 +958,7 @@ export class View {
   private getApplicationState(): State {
     return this.provenance.graph().current.state;
   }
+
 
   private changeOrder(type: string, node: boolean): number[] {
     const action = this.generateSortAction(type);

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -286,33 +286,18 @@ export class View {
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill-opacity', 0);
 
-    const cells = this.edgeRows.selectAll('.cell')
-      .data((d: Node, i: number) => this.matrix[i])
-      .enter()
-      .append('g')
-      .attr('class', 'cell')
-      .attr('id', (d: Cell) => d.cellName)
-      .attr('transform', (d: Cell) => `translate(${this.orderingScale(d.x)},0)`);
-
-    cells
-      .append('rect')
-      .classed('baseCell', true)
-      .attr('x', 0)
-      .attr('height', this.orderingScale.bandwidth())
-      .attr('width', this.orderingScale.bandwidth());
-
     const cellColorScale = scaleLinear<string>()
       .domain([0, this.maxNumConnections])
       .range(['#feebe2', '#690000']); // TODO: colors here are arbitrary, change later
 
-    const squares = cells
+    const cells = this.edgeRows.selectAll('.cell')
+      .data((d: Node, i: number) => this.matrix[i])
+      .enter()
       .append('rect')
-      .attr('x', 0)
+      .attr('x', (d: Cell) => this.orderingScale(d.x))
       .attr('width', this.orderingScale.bandwidth())
       .attr('height', this.orderingScale.bandwidth())
-      .style('fill', (d: Cell) => cellColorScale(d.z));
-
-    squares
+      .style('fill', (d: Cell) => cellColorScale(d.z))
       .style('fill-opacity', (d: Cell) => d.z);
 
     cells

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -39,6 +39,7 @@ export class View {
   private idMap: { [key: string]: number };
   private isMultiEdge: any;
   private orderType: any;
+  private selectedNodesAndNeighbors: { [key: string]: string[] };
   private selectedElements: { [key: string]: string[] };
   private mouseOverEvents: any;
   private maxNumConnections: number = -Infinity;
@@ -51,6 +52,7 @@ export class View {
     this.sortKey = 'name';
     this.matrix = [];
     this.idMap = {};
+    this.selectedNodesAndNeighbors = {};
     this.selectedElements = {};
     this.visualizedAttributes = visualizedAttributes;
 
@@ -630,11 +632,11 @@ export class View {
 
   private selectNeighborNodes(nodeID: string, neighbors: string[]): void {
     // Remove or add node from column selected nodes
-    if (nodeID in this.columnSelectedNodes) {
-      delete this.columnSelectedNodes[nodeID];
+    if (nodeID in this.selectedNodesAndNeighbors) {
+      delete this.selectedNodesAndNeighbors[nodeID];
     } else {
       const newElement = { [nodeID]: neighbors };
-      this.columnSelectedNodes = Object.assign(this.columnSelectedNodes, newElement);
+      this.selectedNodesAndNeighbors = Object.assign(this.selectedNodesAndNeighbors, newElement);
     }
 
     // Reset all nodes to not neighbor highlighted
@@ -643,8 +645,8 @@ export class View {
 
     // Loop through the neighbor nodes to be highlighted and highlight them
     let cssSelector = '';
-    for (const node of Object.keys(this.columnSelectedNodes)) {
-      for (const neighborNode of this.columnSelectedNodes[node]) {
+    for (const node of Object.keys(this.selectedNodesAndNeighbors)) {
+      for (const neighborNode of this.selectedNodesAndNeighbors[node]) {
         cssSelector += `
         [id="attrRow${neighborNode}"],[id="topoRow${neighborNode}"],[id="nodeLabelRow${neighborNode}"],
         `;

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -397,8 +397,8 @@ export class View {
 
 
   private selectElement(element: Cell | Node): void {
-    let elementsToSelect: string = '';
-    let newElement: { [key: string]: string };
+    let elementsToSelect: string[] = [];
+    let newElement: { [key: string]: string[] };
 
     if (this.isCell(element)) {
       // Remove or add cell from selected cells
@@ -406,15 +406,15 @@ export class View {
         delete this.selectedElements[element.cellName];
       } else {
         // Get all the elements to be selected
-        elementsToSelect = `
-        [id="attrRow${element.colID}"],[id="topoRow${element.colID}"],[id="topoCol${element.colID}"],
-        [id="colLabel${element.colID}"],[id="rowLabel${element.colID}"],
+        elementsToSelect = [
+        `[id="attrRow${element.colID}"]`, `[id="topoRow${element.colID}"]`, `[id="topoCol${element.colID}"]`,
+        `[id="colLabel${element.colID}"]`, `[id="rowLabel${element.colID}"]`,
 
-        [id="attrRow${element.rowID}"],[id="topoRow${element.rowID}"],[id="topoCol${element.rowID}"],
-        [id="colLabel${element.rowID}"],[id="rowLabel${element.rowID}"],
+        `[id="attrRow${element.rowID}"]`, `[id="topoRow${element.rowID}"]`, `[id="topoCol${element.rowID}"]`,
+        `[id="colLabel${element.rowID}"]`, `[id="rowLabel${element.rowID}"]`,
 
-        [id="${element.cellName}"],
-        `;
+        `[id="${element.cellName}"]`,
+        ];
         newElement = { [element.cellName]: elementsToSelect};
         this.selectedElements = Object.assign(this.selectedElements, newElement);
       }
@@ -422,10 +422,10 @@ export class View {
       if (element.id in this.selectedElements) {
         delete this.selectedElements[element.id];
       } else {
-        elementsToSelect = `
-        [id="attrRow${element.id}"],[id="topoRow${element.id}"],[id="topoCol${element.id}"],
-        [id="colLabel${element.id}"],[id="rowLabel${element.id}"],
-        `;
+        elementsToSelect = [
+        `[id="attrRow${element.id}"]`, `[id="topoRow${element.id}"]`, `[id="topoCol${element.id}"]`,
+        `[id="colLabel${element.id}"]`, `[id="rowLabel${element.id}"]`,
+        ];
         newElement = { [element.id]: elementsToSelect};
         this.selectedElements = Object.assign(this.selectedElements, newElement);
       }
@@ -437,18 +437,15 @@ export class View {
       .classed('clicked', false);
 
     // Loop through the neighbor nodes to be highlighted and highlight them
-    let cssSelector = '';
+    const selections: string[] = [];
     for (const elementID of Object.keys(this.selectedElements)) {
       for (const elementToSelect of this.selectedElements[elementID]) {
-        cssSelector += elementToSelect;
+        selections.push(elementToSelect);
       }
     }
 
-    // Remove last comma
-    cssSelector = cssSelector.replace(/,\s*$/, '');
-
-    if (cssSelector !== '') {
-      selectAll(cssSelector).classed('clicked', true);
+    if (selections.length > 0) {
+      selectAll(selections.join(',')).classed('clicked', true);
     }
   }
 
@@ -650,20 +647,17 @@ export class View {
       .classed('neighbor', false);
 
     // Loop through the neighbor nodes to be highlighted and highlight them
-    let cssSelector = '';
+    const selections: string[] = [];
     for (const node of Object.keys(this.selectedNodesAndNeighbors)) {
       for (const neighborNode of this.selectedNodesAndNeighbors[node]) {
-        cssSelector += `
-        [id="attrRow${neighborNode}"],[id="topoRow${neighborNode}"],[id="nodeLabelRow${neighborNode}"],
-        `;
+        selections.push(`[id="attrRow${neighborNode}"]`);
+        selections.push(`[id="topoRow${neighborNode}"]`);
+        selections.push(`[id="nodeLabelRow${neighborNode}"]`);
       }
     }
 
-    // Remove last comma
-    cssSelector = cssSelector.replace(/,\s*$/, '');
-
-    if (cssSelector !== '') {
-      selectAll(cssSelector).classed('neighbor', true);
+    if (selections.length > 0) {
+      selectAll(selections.join(',')).classed('neighbor', true);
     }
   }
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -684,7 +684,6 @@ export class View {
       .attr('transform', (d: Node, i: number) =>  `translate(0,${this.orderingScale(i)})`);
 
     // if any other method other than neighbors sort, sort the columns too
-    console.log(order, !nodeIDs.includes(order))
     if (!nodeIDs.includes(order)) {
       this.edges.selectAll('.column')
         .transition()
@@ -700,7 +699,7 @@ export class View {
 
     selectAll('.sortIcon')
       .style('fill', '#8B8B8B')
-      .filter((d) => d.id === order)
+      .filter((d: any) => d.id === order)
       .style('fill', '#EBB769');
   }
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -232,7 +232,7 @@ export class View {
    */
   private initializeEdges(): void {
     // Set width and height based upon the calculated layout size. Grab the smaller of the 2
-    const sideLength = Math.min(this.visDimensions.width, this.visDimensions.height);
+    const sideLength = Math.min(this.visDimensions.width * 0.75, this.visDimensions.height);
 
     // Use the smallest side as the length of the matrix
     this.edgeWidth = sideLength - (this.margins.left + this.margins.right);


### PR DESCRIPTION
Depends on #63 

There are a couple of ideas we had to reduce the hover rendering slowness:

Tried and in the PR:
- Reducing the number of DOM elements (> 10,000 from the cell rendering logic on the miserables graph)

Proposed solutions:
- [ ] Changing the selector
- [ ] Only rendering cells that have a link
These were not tested since reducing the number of elements seems to have fixed the problem.