### PR TITLE
Reshaping cells and removing grid

### DIFF
--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -247,6 +247,12 @@ export class View {
     // set the radius for cells
     const cellRadius = 2;
 
+    // set the size of the number of nodes
+    const matrixNodeLength= this.network.nodes.length;
+
+    // set the matrix highlight
+    const matrixHighlightLength = matrixNodeLength * cellSize;
+
     // Use the smallest side as the length of the matrix
     this.edgeWidth = sideLength - (this.margins.left + this.margins.right);
     this.edgeHeight = sideLength - (this.margins.top + this.margins.bottom);
@@ -258,7 +264,7 @@ export class View {
 
     // sets the vertical scale
     this.orderingScale = scaleBand<number>()
-    .range([0, (this.network.nodes.length * cellSize)]).domain(range(0, this.network.nodes.length, 1));
+    .range([0, (matrixNodeLength * cellSize)]).domain(range(0, matrixNodeLength, 1));
 
     // creates column groupings
     this.edgeColumns = this.edges.selectAll('.column')
@@ -282,17 +288,15 @@ export class View {
 
     this.drawGridLines();
 
-    // set the size of the highlight
-    const matrixHighlight = this.network.nodes.length * cellSize;
 
     // add the highlight columns
     this.edgeColumns
       .append('rect')
       .classed('topoCol', true)
       .attr('id', (d: Node) => `topoCol${d.id}`)
-      .attr('x', -matrixHighlight-this.margins.bottom)
+      .attr('x', -matrixHighlightLength-this.margins.bottom)
       .attr('y', 0)
-      .attr('width', matrixHighlight + this.margins.top + this.margins.bottom)
+      .attr('width', matrixHighlightLength + this.margins.top + this.margins.bottom)
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill-opacity', 0);
 
@@ -303,7 +307,7 @@ export class View {
       .attr('id', (d: Node) => `topoRow${d.id}`)
       .attr('x', -this.margins.left)
       .attr('y', 0)
-      .attr('width', matrixHighlight + this.margins.left + this.margins.right)
+      .attr('width', matrixHighlightLength + this.margins.left + this.margins.right)
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill-opacity', 0);
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -290,9 +290,9 @@ export class View {
       .append('rect')
       .classed('topoCol', true)
       .attr('id', (d: Node) => `topoCol${d.id}`)
-      .attr('x', -this.edgeHeight - this.margins.bottom)
+      .attr('x', -matrixHighlight-this.margins.bottom)
       .attr('y', 0)
-      .attr('width', matrixHighlight + this.margins.bottom + this.margins.top)
+      .attr('width', matrixHighlight + this.margins.top + this.margins.bottom)
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill-opacity', 0);
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -245,7 +245,7 @@ export class View {
     const cellSize = 11;
 
     // set the radius for cells
-    const cellRadius = 5;
+    const cellRadius = 2;
 
     // set the size of the number of nodes
     const matrixNodeLength= this.network.nodes.length;
@@ -322,8 +322,8 @@ export class View {
       .attr('class', 'cell')
       .attr('id', (d: Cell) => d.cellName)
       .attr('x', (d: Cell) => this.orderingScale(d.x))
-      .attr('width', cellSize - 2)
-      .attr('height', cellSize - 2)
+      .attr('width', cellSize - 1)
+      .attr('height', cellSize - 1)
       .attr('rx', cellRadius)
       .style('fill', (d: Cell) => cellColorScale(d.z))
       .style('fill-opacity', (d: Cell) => d.z)

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -284,16 +284,17 @@ export class View {
 
     // set the size of the highlight
     const matrixHighlight = this.network.nodes.length * cellSize;
+
     // add the highlight columns
-    // this.edgeColumns
-    //   .append('rect')
-    //   .classed('topoCol', true)
-    //   .attr('id', (d: Node) => `topoCol${d.id}`)
-    //   .attr('x', -this.edgeHeight - this.margins.bottom)
-    //   .attr('y', 0)
-    //   .attr('width', this.edgeHeight + this.margins.bottom + this.margins.top)
-    //   .attr('height', this.orderingScale.bandwidth())
-    //   .attr('fill-opacity', 0);
+    this.edgeColumns
+      .append('rect')
+      .classed('topoCol', true)
+      .attr('id', (d: Node) => `topoCol${d.id}`)
+      .attr('x', -this.edgeHeight - this.margins.bottom)
+      .attr('y', 0)
+      .attr('width', matrixHighlight + this.margins.bottom + this.margins.top)
+      .attr('height', this.orderingScale.bandwidth())
+      .attr('fill-opacity', 0);
 
     // added highlight rows
     this.edgeRows

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -282,16 +282,18 @@ export class View {
 
     this.drawGridLines();
 
-    // add the highlight rows
-    this.edgeColumns
-      .append('rect')
-      .classed('topoCol', true)
-      .attr('id', (d: Node) => `topoCol${d.id}`)
-      .attr('x', -this.edgeHeight - this.margins.bottom)
-      .attr('y', 0)
-      .attr('width', this.edgeHeight + this.margins.bottom + this.margins.top)
-      .attr('height', this.orderingScale.bandwidth())
-      .attr('fill-opacity', 0);
+    // set the size of the highlight
+    const matrixHighlight = this.network.nodes.length * cellSize;
+    // add the highlight columns
+    // this.edgeColumns
+    //   .append('rect')
+    //   .classed('topoCol', true)
+    //   .attr('id', (d: Node) => `topoCol${d.id}`)
+    //   .attr('x', -this.edgeHeight - this.margins.bottom)
+    //   .attr('y', 0)
+    //   .attr('width', this.edgeHeight + this.margins.bottom + this.margins.top)
+    //   .attr('height', this.orderingScale.bandwidth())
+    //   .attr('fill-opacity', 0);
 
     // added highlight rows
     this.edgeRows
@@ -300,7 +302,7 @@ export class View {
       .attr('id', (d: Node) => `topoRow${d.id}`)
       .attr('x', -this.margins.left)
       .attr('y', 0)
-      .attr('width', this.edgeWidth + this.margins.right + this.margins.left)
+      .attr('width', matrixHighlight + this.margins.left + this.margins.right)
       .attr('height', this.orderingScale.bandwidth())
       .attr('fill-opacity', 0);
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -562,35 +562,35 @@ export class View {
       .data(this.matrix)
       .enter();
 
-    lines.append('line')
-      .attr('transform', (d: any, i: number) => {
-        return `translate(${this.orderingScale(i)},0)rotate(-90)`;
-      })
-      .attr('x1', -this.orderingScale.range()[1]);
+    // lines.append('line')
+    //   .attr('transform', (d: any, i: number) => {
+    //     return `translate(${this.orderingScale(i)},0)rotate(-90)`;
+    //   })
+    //   .attr('x1', -this.orderingScale.range()[1]);
 
-    lines.append('line')
-      .attr('transform', (d: any, i: number) => {
-        return `translate(0,${this.orderingScale(i)})`;
-      })
-      .attr('x2', this.orderingScale.range()[1]);
+    // lines.append('line')
+    //   .attr('transform', (d: any, i: number) => {
+    //     return `translate(0,${this.orderingScale(i)})`;
+    //   })
+    //   .attr('x2', this.orderingScale.range()[1]);
 
-    gridLines
-      .append('line')
-      .attr('x1', this.orderingScale.range()[1])
-      .attr('x2', this.orderingScale.range()[1])
-      .attr('y1', 0)
-      .attr('y2', this.orderingScale.range()[1])
-      .style('stroke', '#aaa')
-      .style('opacity', 0.3);
+    // gridLines
+    //   .append('line')
+    //   .attr('x1', this.orderingScale.range()[1])
+    //   .attr('x2', this.orderingScale.range()[1])
+    //   .attr('y1', 0)
+    //   .attr('y2', this.orderingScale.range()[1])
+    //   .style('stroke', '#aaa')
+    //   .style('opacity', 0.3);
 
-    gridLines
-      .append('line')
-      .attr('x1', 0)
-      .attr('x2', this.orderingScale.range()[1])
-      .attr('y1', this.orderingScale.range()[1])
-      .attr('y2', this.orderingScale.range()[1])
-      .style('stroke', '#aaa')
-      .style('opacity', 0.3);
+    // gridLines
+    //   .append('line')
+    //   .attr('x1', 0)
+    //   .attr('x2', this.orderingScale.range()[1])
+    //   .attr('y1', this.orderingScale.range()[1])
+    //   .attr('y2', this.orderingScale.range()[1])
+    //   .style('stroke', '#aaa')
+    //   .style('opacity', 0.3);
 
   }
 

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -245,7 +245,7 @@ export class View {
     const cellSize = 11;
 
     // set the radius for cells
-    const cellRadius = 2;
+    const cellRadius = 5;
 
     // set the size of the number of nodes
     const matrixNodeLength= this.network.nodes.length;
@@ -322,8 +322,8 @@ export class View {
       .attr('class', 'cell')
       .attr('id', (d: Cell) => d.cellName)
       .attr('x', (d: Cell) => this.orderingScale(d.x))
-      .attr('width', cellSize)
-      .attr('height', cellSize)
+      .attr('width', cellSize - 2)
+      .attr('height', cellSize - 2)
       .attr('rx', cellRadius)
       .style('fill', (d: Cell) => cellColorScale(d.z))
       .style('fill-opacity', (d: Cell) => d.z)

--- a/src/components/AdjMatrix/AdjMatrixMethods.ts
+++ b/src/components/AdjMatrix/AdjMatrixMethods.ts
@@ -241,6 +241,12 @@ export class View {
     // Set width and height based upon the calculated layout size. Grab the smaller of the 2
     const sideLength = Math.min(this.matrixWidth, this.matrixHeight);
 
+    // set the dimensions of a cell
+    const cellSize = 11;
+
+    // set the radius for cells
+    const cellRadius = 2;
+
     // Use the smallest side as the length of the matrix
     this.edgeWidth = sideLength - (this.margins.left + this.margins.right);
     this.edgeHeight = sideLength - (this.margins.top + this.margins.bottom);
@@ -252,7 +258,7 @@ export class View {
 
     // sets the vertical scale
     this.orderingScale = scaleBand<number>()
-    .range([0, this.edgeHeight]).domain(range(0, this.network.nodes.length, 1));
+    .range([0, (this.network.nodes.length * cellSize)]).domain(range(0, this.network.nodes.length, 1));
 
     // creates column groupings
     this.edgeColumns = this.edges.selectAll('.column')
@@ -309,8 +315,9 @@ export class View {
       .attr('class', 'cell')
       .attr('id', (d: Cell) => d.cellName)
       .attr('x', (d: Cell) => this.orderingScale(d.x))
-      .attr('width', this.orderingScale.bandwidth())
-      .attr('height', this.orderingScale.bandwidth())
+      .attr('width', cellSize)
+      .attr('height', cellSize)
+      .attr('rx', cellRadius)
       .style('fill', (d: Cell) => cellColorScale(d.z))
       .style('fill-opacity', (d: Cell) => d.z)
       .on('mouseover', (d: Cell, i: number, nodes: any) => {


### PR DESCRIPTION
This branch implements Roni's ideas about the UI with removing the gridlines and reshaping the filled cells so they do not touch. This branch also relies on the changes made in the revised-grid-layout branch
![Selection_003](https://user-images.githubusercontent.com/24800816/89826278-dea91400-db0a-11ea-87b1-7e880d29903c.png)
