### PR TITLE
Add Blinker font as the main font for the app

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Multinet - Adjacency Matrix</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Blinker:wght@100;200;300;400;600;700;800;900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ export default {
 
 <style scoped>
 #app {
-  font-family: "Avenir", Helvetica, Arial, sans-serif;
+  font-family: Blinker, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow: none;


### PR DESCRIPTION
Closes #90.

Adds the Blinker font from Google Fonts, as specified by @jtomeck. I also fixed the import of roboto to use the new `css2` endpoint from google