### PR TITLE
Implement Grid Toggle for Showing/Hiding Matrix Gridlines

### DIFF
--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -15,10 +15,6 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
-    showGridLines: {
-      type: Boolean,
-      default: true,
-    },
     visualizedAttributes: {
       type: Array,
       default: () => [],

--- a/src/components/AdjMatrix/AdjMatrix.vue
+++ b/src/components/AdjMatrix/AdjMatrix.vue
@@ -15,6 +15,10 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
+    showGridLines: {
+      type: Boolean,
+      default: true,
+    },
     visualizedAttributes: {
       type: Array,
       default: () => [],

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -69,10 +69,8 @@ export default Vue.extend({
   watch: {
     showGridLines: function () {
       if (this.showGridLines) {
-        // console.log('show gridlines');
         selectAll('.gridLines').attr('opacity', 1);
       } else {
-        // console.log('hide grid lines');
         selectAll('.gridLines').attr('opacity', 0);
       }
     },

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -99,10 +99,36 @@ export default Vue.extend({
               Autoselect neighbors
               <v-switch class="ma-0" v-model="selectNeighbors" hide-details />
             </v-card-subtitle>
+            <v-card-subtitle
+              class="pb-0 px-0"
+              style="
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+              "
+            >
+              Show GridLines
+              <v-switch class="ma-0" v-model="showGridLines" hide-details />
+            </v-card-subtitle>
+            <v-card-subtitle
+              class="pb-0 px-0"
+              style="
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+              "
+            >
+              Show GridLines
+              <v-checkbox class="ma-0" v-model="showGridLines" hide-details />
+            </v-card-subtitle>
+            
           </v-card-text>
 
           <v-card-actions>
             <v-btn small @click="exportNetwork">Export Network</v-btn>
+          </v-card-actions>
+          <v-card-actions>
+            <v-btn small> Show Gridlines</v-btn>
           </v-card-actions>
         </v-card>
       </v-col>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -110,7 +110,6 @@ export default Vue.extend({
               Show GridLines
               <v-checkbox class="ma-0" v-model="showGridLines" hide-details />
             </v-card-subtitle>
-            
           </v-card-text>
 
           <v-card-actions>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -16,6 +16,7 @@ export default Vue.extend({
     workspace: string;
     networkName: string;
     selectNeighbors: boolean;
+    showGridLines: boolean;
     visualizedAttributes: string[];
   } {
     return {
@@ -26,6 +27,7 @@ export default Vue.extend({
       workspace: '',
       networkName: '',
       selectNeighbors: true,
+      showGridLines: true,
       visualizedAttributes: [],
     };
   },
@@ -127,6 +129,7 @@ export default Vue.extend({
             v-bind="{
               network,
               selectNeighbors,
+              showGridLines,
               visualizedAttributes,
             }"
             @restart-simulation="hello()"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import AdjMatrix from '@/components/AdjMatrix/AdjMatrix.vue';
-
+import { selectAll } from 'd3-selection';
 import { getUrlVars } from '@/lib/utils';
 import { loadData } from '@/lib/multinet';
 import { Network } from '@/types';
@@ -64,6 +64,17 @@ export default Vue.extend({
       );
       a.download = `${this.networkName}.json`;
       a.click();
+    },
+  },
+  watch: {
+    showGridLines: function () {
+      if (this.showGridLines) {
+        // console.log('show gridlines');
+        selectAll('.gridLines').attr('opacity', 1);
+      } else {
+        // console.log('hide grid lines');
+        selectAll('.gridLines').attr('opacity', 0);
+      }
     },
   },
 });

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -108,17 +108,6 @@ export default Vue.extend({
               "
             >
               Show GridLines
-              <v-switch class="ma-0" v-model="showGridLines" hide-details />
-            </v-card-subtitle>
-            <v-card-subtitle
-              class="pb-0 px-0"
-              style="
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-              "
-            >
-              Show GridLines
               <v-checkbox class="ma-0" v-model="showGridLines" hide-details />
             </v-card-subtitle>
             
@@ -126,9 +115,6 @@ export default Vue.extend({
 
           <v-card-actions>
             <v-btn small @click="exportNetwork">Export Network</v-btn>
-          </v-card-actions>
-          <v-card-actions>
-            <v-btn small> Show Gridlines</v-btn>
           </v-card-actions>
         </v-card>
       </v-col>


### PR DESCRIPTION
This branch creates the grid toggle for showing/hiding the grid lines for the matrix.

The following images displays different kinds of toggles for showing/hiding the gridlines. The toggle selected was the checkbox because it easy to understand how to use and connects well with the adjacency matrix.
![image](https://user-images.githubusercontent.com/24800816/92984714-015b7f00-f461-11ea-96ce-3900b2694161.png)
