### PR TITLE
Change the lone v-switch to a v-checkbox

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -108,7 +108,7 @@ export default Vue.extend({
               "
             >
               Autoselect neighbors
-              <v-switch class="ma-0" v-model="selectNeighbors" hide-details />
+              <v-checkbox class="ma-0" v-model="selectNeighbors" hide-details />
             </v-card-subtitle>
             <v-card-subtitle
               class="pb-0 px-0"


### PR DESCRIPTION
After #102, which uses a checkbox instead of a switch, the remaining switch in the UI feels out of place, and a checkbox seems like the better choice.

This tiny PR changes that switch to a checkbox.