### PR TITLE
Add authentication token receiving from the querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/d3": "^5.7.2",
     "core-js": "^3.4.3",
     "d3": "^5.14.2",
-    "multinet": "^0.14.0",
+    "multinet": "^0.17.0",
     "provenance-lib-core": "^6.0.0",
     "reorder.js": "^1.0.6",
     "science": "^1.9.3",

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -74,7 +74,6 @@ export default Vue.extend({
 
       if (result !== null) {
         const { index, 1: token } = result;
-        console.log(index, token);
 
         const newPath = window.location.href.slice(0, index);
         window.history.replaceState({}, window.document.title, newPath);

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -6,7 +6,7 @@ import { getUrlVars } from '@/lib/utils';
 import { loadData } from '@/lib/multinet';
 import { Network } from '@/types';
 
-const loginTokenRegex = /&loginToken=(\S+)/;
+const loginTokenRegex = /#loginToken=(\S+)/;
 export default Vue.extend({
   components: {
     AdjMatrix,

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -6,7 +6,7 @@ import { getUrlVars } from '@/lib/utils';
 import { loadData } from '@/lib/multinet';
 import { Network } from '@/types';
 
-const loginTokenRegex = /&token=(\S+)/;
+const loginTokenRegex = /&loginToken=(\S+)/;
 export default Vue.extend({
   components: {
     AdjMatrix,
@@ -50,9 +50,9 @@ export default Vue.extend({
         `Workspace and network must be set! workspace=${workspace} network=${networkName}`,
       );
     }
-    const token = this.checkUrlForLogin();
+    const loginToken = this.checkUrlForLogin();
 
-    this.network = await loadData(workspace, networkName, host, token);
+    this.network = await loadData(workspace, networkName, host, loginToken);
     this.workspace = workspace;
     this.networkName = networkName;
   },
@@ -69,7 +69,7 @@ export default Vue.extend({
       a.click();
     },
 
-    checkUrlForLogin(this: any): string {
+    checkUrlForLogin(this: any): string | null {
       const result = loginTokenRegex.exec(window.location.href);
 
       if (result !== null) {
@@ -80,7 +80,7 @@ export default Vue.extend({
         return token;
       }
 
-      return '';
+      return null;
     },
   },
   watch: {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -6,6 +6,7 @@ import { getUrlVars } from '@/lib/utils';
 import { loadData } from '@/lib/multinet';
 import { Network } from '@/types';
 
+const loginTokenRegex = /&token=(\S+)/;
 export default Vue.extend({
   components: {
     AdjMatrix,
@@ -49,7 +50,9 @@ export default Vue.extend({
         `Workspace and network must be set! workspace=${workspace} network=${networkName}`,
       );
     }
-    this.network = await loadData(workspace, networkName, host);
+    const token = this.checkUrlForLogin();
+
+    this.network = await loadData(workspace, networkName, host, token);
     this.workspace = workspace;
     this.networkName = networkName;
   },
@@ -64,6 +67,21 @@ export default Vue.extend({
       );
       a.download = `${this.networkName}.json`;
       a.click();
+    },
+
+    checkUrlForLogin(this: any): string {
+      const result = loginTokenRegex.exec(window.location.href);
+
+      if (result !== null) {
+        const { index, 1: token } = result;
+        console.log(index, token);
+
+        const newPath = window.location.href.slice(0, index);
+        window.history.replaceState({}, window.document.title, newPath);
+        return token;
+      }
+
+      return '';
     },
   },
   watch: {

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -70,7 +70,7 @@ export async function loadData(
   workspace: string,
   networkName: string,
   apiRoot: string = process.env.VUE_APP_MULTINET_HOST,
-  loginToken: string,
+  loginToken: string | null,
 ): Promise<Network> {
   // Define local variables that will store the api url and the responses from the database
   const multinet: {

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -70,7 +70,7 @@ export async function loadData(
   workspace: string,
   networkName: string,
   apiRoot: string = process.env.VUE_APP_MULTINET_HOST,
-  token: string
+  token: string,
 ): Promise<Network> {
   // Define local variables that will store the api url and the responses from the database
   const multinet: {
@@ -86,7 +86,7 @@ export async function loadData(
   };
 
   const api = multinetApi(apiRoot);
-  api.setAuthToken(token)
+  api.setAuthToken(token);
 
   // Fetch the names of all the node and edge tables
   multinet.tables = await api.graph(workspace, networkName);

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -70,7 +70,7 @@ export async function loadData(
   workspace: string,
   networkName: string,
   apiRoot: string = process.env.VUE_APP_MULTINET_HOST,
-  token: string,
+  loginToken: string,
 ): Promise<Network> {
   // Define local variables that will store the api url and the responses from the database
   const multinet: {
@@ -86,7 +86,10 @@ export async function loadData(
   };
 
   const api = multinetApi(apiRoot);
-  api.setAuthToken(token);
+
+  if (loginToken !== null) {
+    api.setAuthToken(loginToken);
+  }
 
   // Fetch the names of all the node and edge tables
   multinet.tables = await api.graph(workspace, networkName);

--- a/src/lib/multinet.ts
+++ b/src/lib/multinet.ts
@@ -70,6 +70,7 @@ export async function loadData(
   workspace: string,
   networkName: string,
   apiRoot: string = process.env.VUE_APP_MULTINET_HOST,
+  token: string
 ): Promise<Network> {
   // Define local variables that will store the api url and the responses from the database
   const multinet: {
@@ -85,6 +86,7 @@ export async function loadData(
   };
 
   const api = multinetApi(apiRoot);
+  api.setAuthToken(token)
 
   // Fetch the names of all the node and edge tables
   multinet.tables = await api.graph(workspace, networkName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7177,10 +7177,10 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-multinet@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.14.0.tgz#7800f75127b90b35b98069a69d8e36ebf970144e"
-  integrity sha512-AZFQoXQUtsRJvoHqBu8koJNOAyUiWH3yKmCoL9UBl6+e+YG4j1nGlQ+tp0PnKixnh8M/kjr5hysqXWX7zF1X+A==
+multinet@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0.tgz#05b30b85d29af8cb877bed502d8cacdabe8796ed"
+  integrity sha512-EC+ALY7ciwSmbkC49NE5A0OmFYxjt/QrTPQf7sXDeL6FUi74UKaammlN3E11T4Pur3kNx686AycmKSbgCkPHNA==
   dependencies:
     axios "^0.19.0"
 


### PR DESCRIPTION
Adds a method to grab the login token from the query string so that a user can view data from private workspaces. This function is slightly different to that created by @AlmightyYakob, since we're not using vue router on this project, and the api is only handled in one spot on first load -- it's not continually accessed, unlike the main client.